### PR TITLE
Fix premature removal

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -196,7 +196,17 @@ class TestGenerateSingle(unittest.TestCase):
                                       'PSLFWHYKALMPAGNCI', 
                                       'FNGIYADPSGHCNFFWPSLFW', 
                                       'FNGAYADPSGHCNFFWPSLFW'])
-
+        
+    def test_nocanonicalmiscleavage(self):
+        """Test that 2 canonical peptides without variants will not
+            get miscleaved together
+        """        
+        aa_string = "FNGIYADWSGHCNFFWPSLFSHYKALMPAGNCI"
+        peptide = vc.Peptide(aa_string, 'identifier', 'gene')
+        res = varpepdb.generate_single(variants=[generatevariant(peptide, 32, 'K')],
+                                        sequence=aa_string, gene='protein')
+        
+        self.assertsequenceprop(res, ['PSLFSHYKALMPAGNCK', 'SGHCNFFWPSLFSHYKALMPAGNCK'])
 
 if __name__ == "__main__":
     unittest.main()

--- a/varpepdb/classes.py
+++ b/varpepdb/classes.py
@@ -165,7 +165,8 @@ class Peptide:
             applied_nonenzymevariants = []
         self.applied_nonenzymevariants = applied_nonenzymevariants
 
-        self.nenzymevariants = len(applied_enzymevariants)
+        self.n_applied_enzymevar = len(applied_enzymevariants)
+        self.n_applied_nonenzymevar = len(applied_nonenzymevariants)
 
     def __contains__(self, other: SAP):
         return other.pos >= self.start and other.pos <= self.end
@@ -188,7 +189,6 @@ class Peptide:
 
         new_applied_enzymevariants = self.applied_enzymevariants[:] + \
             [i for i in other.applied_enzymevariants if i not in self.applied_enzymevariants]
-
         new_applied_nonenzymevariants = self.applied_nonenzymevariants + other.applied_nonenzymevariants
 
         newinstance = self.__class__(aa_string=self._seq+other._seq,
@@ -312,10 +312,11 @@ class Peptide:
             if one_change[2]:  # If there is a SAP object
                 if variant_type == 'enzyme':
                     self.applied_enzymevariants.append(one_change[2])
-                    self.nenzymevariants += 1
+                    self.n_applied_enzymevar += 1
 
                 elif variant_type == 'nonenzyme':
                     self.applied_nonenzymevariants.append(one_change[2])
+                    self.n_applied_nonenzymevar += 1
 
     def add_enzyme_variants(self, v):
         self.check_variant(v)

--- a/varpepdb/core.py
+++ b/varpepdb/core.py
@@ -450,6 +450,8 @@ def _cleave_breaker_peptides(peptide: vc.Peptide) -> List[vc.Peptide]:
         if peptide.not_too_long():  # Keep peptides for miscleavaging later
             peptide.miscleave_count = 0
             cleaved_peptides = [peptide]
+        else:
+            cleaved_peptides = []
 
     else:
         # Apply variants and cleave


### PR DESCRIPTION
Fixed the premature removal of peptides that do not contain substitutions that affect enzyme cleavage. 
Miscleavages can include canonical peptides as long as 1 peptide contains variant. 

Non-unique sequences have version number appended at the back now.  Fixed #1 